### PR TITLE
Fix NameError: name 'MKGeneralException' is not defined (https://gith…

### DIFF
--- a/checks/v2/robotmk.py
+++ b/checks/v2/robotmk.py
@@ -28,6 +28,7 @@ from dateutil import parser
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from string import Template
+from cmk.utils.exceptions import MKGeneralException
 
 # UTC = pytz.utc
 


### PR DESCRIPTION
…ub.com/simonmeggle/robotmk/issues/138)

Fixes the following error: 

```
  File "/omd/sites/sitename/local/lib/python3/cmk/base/plugins/agent_based/robotmk.py", line 67, in parse_robotmk
    raise MKGeneralException(
NameError: name 'MKGeneralException' is not defined
```

I've tested this on CheckMK version `2.0.0p6.cee`